### PR TITLE
Add o3DS version table and error correction to work on more versions

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -7,6 +7,6 @@
 #define PULSE_EVENT 2
 
 /* sets upper 32 bits of timer to kernel_callback_int */
-bool set_timer(Handle timer, u32 kernel_callback_int);
+bool set_timer(Handle timer, u32 kernel_callback_int, int error);
 
 #endif /* __TIMER_H */

--- a/source/exploit.c
+++ b/source/exploit.c
@@ -130,7 +130,7 @@ bool initialize_timer_state() {
   timeout /= 3;
   svcCancelTimer(timer2);
 
-  if (!set_timer(timer2, 0xaaa00000)) {
+  if (!set_timer(timer2, 0xaaa00000, 0)) {
     printf("set_timer_test: set_timer failed\n");
     svcCloseHandle(timer2);
     svcCloseHandle(timer);
@@ -138,13 +138,15 @@ bool initialize_timer_state() {
   }
 
   // goal: 0xFFF1B65C
-  if (!set_timer(timer2, (u32)timeout)) {
+  if (!set_timer(timer2, (u32)timeout, (u32)RandomStub - ((u32)timeout)*3)) {
     printf("set_timer_test: set_timer failed\n");
     svcCloseHandle(timer2);
     svcCloseHandle(timer);
     return false;
   }
 
+  //return false;
+  
   if (mybackdoor_installed()) {
     u64 initial = 0;
     if (!get_timer_value(timer2, &initial, NULL)) {
@@ -230,6 +232,7 @@ typedef struct version_table {
   u32 svc_handler_table;
 } version_table;
 
+// New 3DS
 static version_table n_table[] = {
   {SYSTEM_VERSION(2, 46, 0),  0xFFF18D5C, 0xFFF1B1A4, 0xFFF02300},  // 9.0
   {SYSTEM_VERSION(2, 48, 3),  0xFFF18AFC, 0xFFF1B188, 0xFFF02310},  // 9.3
@@ -244,14 +247,18 @@ static version_table n_table[] = {
   {0},
 };
 
+// Old 3DS
+static version_table o_table[] = {
+  {SYSTEM_VERSION(2, 52, 0),  0xfff18aa0, 0xfff1b30c, 0xfff02328},  // 11.2
+  {0},
+};
+
 bool initialize_handle_address() {
   u32 kver = osGetKernelVersion();
   bool n3ds = false;
   APT_CheckNew3DS(&n3ds);
-  if (!n3ds) {
-    return false;
-  }
-  version_table *table = n_table;
+
+  version_table *table = n3ds ? n_table : o_table;
   while (table->kver) {
     if (table->kver == kver) {
       handle_lookup_kern = (void*)table->handle_lookup;


### PR DESCRIPTION
 - Simple Version Table for Old 3DS, currently only 11.2
 - Automatic error correction to overflow to the right address when not dividable by 3

Successfully tested on my 11.2E Old 3DS.